### PR TITLE
Tweak workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Debug
+        run: |
+          printenv | sort
+
       - name: Test
         run: go test -v ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,23 +69,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify tag commit is this commit
-        run: |
-          CURRENT_COMMIT=$(git rev-parse HEAD)
-          TAG_COMMIT=$(git rev-list -n 1 $GITHUB_REF)
-          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
-            echo "tag commit $TAG_COMMIT != head $CURRENT_COMMIT"
-            exit 1
-          fi
-
       - name: Set up Go
-        if: success()
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        if: success()
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Debug
-        run: |
-          printenv | sort
+      # - name: Debug
+      #   run: |
+      #     printenv | sort
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify tag commit is this commit
+        run: |
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          TAG_COMMIT=$(git rev-list -n 1 $GITHUB_REF)
+          if [ "$CURRENT_COMMIT" != "$TAG_COMMIT" ]; then
+            echo "tag commit $TAG_COMMIT != head $CURRENT_COMMIT"
+            exit 1
+          fi
+
       - name: Set up Go
+        if: success()
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
       - name: Run GoReleaser
+        if: success()
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser


### PR DESCRIPTION
I tried to change the workflow so that `goreleaser` would not run if the commit associated with the tag was not pushed, but it didn't work, and it made the workflow more complicated.  So I am backing out.